### PR TITLE
Maven build auf shade umgestellt und SuperMain.class eingefuehrt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.8.2</junit.version>
         <java.version>21</java.version>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
     </properties>
 
     <dependencies>
@@ -50,13 +52,23 @@
         <testSourceDirectory>src/test</testSourceDirectory>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.9.0</version>
-                <configuration>
-                    <source>21</source>
-                    <target>21</target>
-                </configuration>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.example.fahrtenbuch.SuperMain</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.openjfx</groupId>

--- a/src/main/java/com/example/fahrtenbuch/SuperMain.java
+++ b/src/main/java/com/example/fahrtenbuch/SuperMain.java
@@ -1,0 +1,7 @@
+package com.example.fahrtenbuch;
+
+public class SuperMain {
+    public static void main(String[] args) {
+        LogbookApplication.main(args);
+    }
+}


### PR DESCRIPTION
* Build auf `maven-shade-plugin` umgestellt: https://maven.apache.org/plugins/maven-shade-plugin/

* Entsprechend dem nächsten Stackoverflow-Post einen Workaround für JavaFx und Maven mittels einer "SuperMain" Klasse ohne der Vererbung von *Application* umgesetzt: https://stackoverflow.com/questions/57019143/build-executable-jar-with-javafx11-from-maven